### PR TITLE
Extend Keycodes, Uppercase Characters in type_keys, delete_text

### DIFF
--- a/WWW-WebKit/lib/WWW/WebKit.pm
+++ b/WWW-WebKit/lib/WWW/WebKit.pm
@@ -618,6 +618,7 @@ my %keycodes = (
     ' '    => 65,  # Space
     '\032' => 65,  # Space
     '\127' => 119, # Delete
+    '\8'   => 22,  # Backspace
     '\044' => 59,  # Comma
     ','    => 59,  # Comma
     '\045' => 20,  # Hyphen
@@ -666,6 +667,24 @@ sub type_keys {
         $self->key_press($locator, $_, $element) or return;
         $self->shift_key_up if $self->is_upper_case($_);
     }
+
+    return 1;
+}
+
+=head3 delete_text($locator)
+
+Delete text in elements where contenteditable="true".
+
+=cut
+
+sub delete_text {
+    my ($self, $locator) = @_;
+
+    my $element = $self->resolve_locator($locator) or return;
+
+    while ($self->get_text($locator)) {
+        $self->key_press($locator, '\127', $element); # Delete
+    };
 
     return 1;
 }

--- a/WWW-WebKit/t/01load.t
+++ b/WWW-WebKit/t/01load.t
@@ -109,6 +109,14 @@ $sel->wait_for_condition(sub {
     URI->new($sel->view->get_uri)->query eq 'foo=1%2C5+Bar'
 });
 
+$sel->open("$Bin/test/delete.html");
+$sel->delete_text('id=foo');
+$sel->delete_text('id=bar');
+$sel->click('id=submit');
+$sel->wait_for_condition(sub {
+    URI->new($sel->view->get_uri)->query eq 'foo2=&bar2=&baz2=27+Baz'
+});
+
 $sel->open("$Bin/test/select.html");
 $sel->select('id=test', 'value=1');
 is(pop @{ $sel->alerts }, 'onchange fired');

--- a/WWW-WebKit/t/test/delete.html
+++ b/WWW-WebKit/t/test/delete.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+        <script type="text/javascript">
+            function setValues() {
+                document.getElementById('foo2').value = document.querySelector(".foo_name").textContent;
+                document.getElementById('bar2').value = document.querySelector(".bar_name").textContent;
+                document.getElementById('baz2').value = document.querySelector(".baz_name").textContent;
+            }
+        </script>
+    </head>
+    <body>
+        <div>
+            <form action="" method="get" onSubmit="return setValues()">
+                <input name="foo2" id="foo2" type="hidden">
+                <input name="bar2" id="bar2" type="hidden">
+                <input name="baz2" id="baz2" type="hidden">
+                <div>
+                    <table>
+                        <tbody>
+                            <tr data-type="article">
+                                <td class="foo_name" contenteditable="true" name="foo" id="foo">Foo Bar Baz<br>01.06.2014 - 31.12.2014</td>
+                                <td class="bar_name" contenteditable="true" name="bar" id="bar">7 Baz</td>
+                                <td class="baz_name" contenteditable="true" name="baz" id="baz">27 Baz</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <button type="submit" id="submit">submit</button>
+            </form>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
delete_text kann nicht automatisch mit mehrzeiligen Textfeldern umgehen. Durch den $length-Parameter kann man aber die Anzahl der Delete-Tastendrücke steuern, damit auch in mehrzeiligen Feldern alle Zeichen gelöscht werden.
